### PR TITLE
handling arrays

### DIFF
--- a/app/controllers/style_items_controller.rb
+++ b/app/controllers/style_items_controller.rb
@@ -13,7 +13,7 @@ class StyleItemsController < ApplicationController
   end
 
   def update
-    if @style_item.update_attributes(style_item_params)
+    if @style_item.update_attributes!(update_params)
       flash[:success] = "Your style_item entry was updated successfully"
       redirect_to store_style_item_path(store_id: @store.id, id: @style_item.id)
     else
@@ -52,8 +52,13 @@ class StyleItemsController < ApplicationController
     @store = Store.find(params[:store_id])
   end
 
-  def style_item_params
+  def update_params
+    update_params = style_item_params.to_h
+    update_params[:picture] = update_params[:picture].first
+    update_params
+  end
 
-    params.permit(:store_id, :item_type, :description, :picture, :picture_cache)
+  def style_item_params
+    params.permit(:store_id, :item_type, :description, picture: [])
   end
 end

--- a/app/views/style_items/_form.html.erb
+++ b/app/views/style_items/_form.html.erb
@@ -19,7 +19,6 @@
 
   <label>Image:</label><br>
   <%= file_field :picture, @style_item.picture %>
-  <%= hidden_field :picture_cache, @style_item.picture_cache %>
 
   <%= submit_tag "Submit Changes" %>
 <% end %>


### PR DESCRIPTION
The problem here is that the form is submitting the file as an array of files (I think this is what Rails `file_field` method does), but Carrierwave is configured on StyleItem to only accept a single image. This is why we have `mount_uploader` vs `mount_uploaders` (which is what we'd use if you wanted multiple images) and why the picture column in your database is set to a string (you'd have to use some weird JSON format for multiple images).

The Carrierwave documentation doesn't cover this distinction well in my opinion. To handle the array coming from the form we need to whitelist the array type in the strong params. From there we can't directly save the array in the database since we have it set up to only take a string (aka the file path for a single image). I added a new params method that will pull off the first element in the array and reset the `:picture` key on the params hash. This probably won't handle submitting the update form without a picture upload, but you can worry about that later.

I also removed `picture_cache` from the form since we aren't really doing anything with it.